### PR TITLE
SESP-240: Remove from the report name the charater(–) that cause the …

### DIFF
--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupMisauResumoMensalPrepReport.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupMisauResumoMensalPrepReport.java
@@ -67,7 +67,7 @@ public class SetupMisauResumoMensalPrepReport extends EptsPeriodIndicatorDataExp
 
   @Override
   public String getName() {
-    return "Resumo Mensal da PrEP – MISAU";
+    return "Resumo Mensal da PrEP - MISAU";
   }
 
   @Override

--- a/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupResumoMensalReport.java
+++ b/api/src/main/java/org/openmrs/module/eptsreports/reporting/reports/SetupResumoMensalReport.java
@@ -59,7 +59,7 @@ public class SetupResumoMensalReport extends EptsPeriodIndicatorDataExportManage
 
   @Override
   public String getName() {
-    return "Resumo Mensal US HIV/SIDA – Ficha Mestre";
+    return "Resumo Mensal US HIV/SIDA - Ficha Mestre";
   }
 
   @Override


### PR DESCRIPTION
…excel report to be downloaded with viewreport in filename